### PR TITLE
Invite the bot to a room and ask it to leave

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,29 @@
-unbot
-=======
+# unbot
 
 A simple extensible hipchat bot written in clojure
+
+# Configure
+
+```javascript
+# resources/config.json
+{
+    "server-port": 9000,
+    "bots": [{
+        "id": "hipchat",
+        "connection": {
+            "type": "hipchat",
+            "conf": {
+                "user": "1234_567890@chat.hipchat.com",
+                "pass": "**********",
+                "nick": "Bert Bot",
+                "mention": "@bert",
+                "rooms": [
+                  "1234_war_room",
+                  "2345_lunch_room"
+                ]
+            }
+        },
+        "plugins": ["weather", "jenkins", "docker"]
+    }]
+}
+```


### PR DESCRIPTION
This adds functionality to invite the bot using XMPP invitations (⌘I in the Mac app), as well as a listener to leave rooms when someone says `@mention leave` or `@mention go away`.

This also introduces a breaking change to the `config.json` (see README).
